### PR TITLE
Node config fix

### DIFF
--- a/examples/quickstart/node_react/.env.example
+++ b/examples/quickstart/node_react/.env.example
@@ -1,5 +1,4 @@
-NILE_BASE_PATH = "https://api.thenile.dev"
+NILE_HOST = db.thenile.dev
 NILE_DATABASE = 
-NILE_WORKSPACE = 
 NILE_USER = 
 NILE_PASSWORD = 

--- a/examples/quickstart/node_react/README.md
+++ b/examples/quickstart/node_react/README.md
@@ -42,9 +42,8 @@ Also fill in the username and password with the credentials you picked up in the
 It should look something like this:
 
 ```bash
-NILE_BASE_PATH = "https://api.thenile.dev"
+NILE_HOST = db.thenile.dev
 NILE_DATABASE = "main"
-NILE_WORKSPACE = "todoapp"
 NILE_USER = "018a6b69-b1e9-7574-b8f3-efd5fe63d9bb"
 NILE_PASSWORD = "d757518e-6d52-4bdb-b85f-f008c9f80097"
 ```

--- a/examples/quickstart/node_react/src/be/app.ts
+++ b/examples/quickstart/node_react/src/be/app.ts
@@ -4,7 +4,7 @@ import Server from "@theniledev/server";
 import Knex from "knex";
 
 export const { db } = Server({
-  workspace: String(process.env.NILE_WORKSPACE),
+  workspace: "", // leaving this empty, as we don't need it for this example
   database: String(process.env.NILE_DATABASE),
   db: {
     connection: {

--- a/www/app/docs/getting-started/[[...slug]]/languages/node.mdx
+++ b/www/app/docs/getting-started/[[...slug]]/languages/node.mdx
@@ -52,7 +52,8 @@ Rename `.env.example` to `.env`
 Update NILE_USER and NILE_PASSWORD with the credentials you picked up in the previous step.
 
 ```bash
-NILE_BASE_PATH = "https://api.thenile.dev"
+NILE_DATABASE = "demo_db_1"
+NILE_HOST = "db.thenile.dev"
 NILE_USER = "018a6b69-b1e9-7574-b8f3-efd5fe63d9bb"
 NILE_PASSWORD = "d757518e-6d52-4bdb-b85f-f008c9f80097"
 ```


### PR DESCRIPTION
Cleaned up the examples config a bit, and fixed a bug - the DB connection config was missing the db hostname. 

Working here: https://demo-todo-node.fly.dev