### PR TITLE
docs: Fix typo in AI embeddings sidebar

### DIFF
--- a/www/app/docs/ai-embeddings/[[...slug]]/pg_vector/index.mdx
+++ b/www/app/docs/ai-embeddings/[[...slug]]/pg_vector/index.mdx
@@ -2,7 +2,7 @@
 
 export const metadata = {
   order: 1,
-  title: "Getting started with pg_ventor",
+  title: "Getting started with pg_vector",
   description: "perform operations on vectors directly within niledatabase",
 };
 


### PR DESCRIPTION
There's a typo in the sidebar item & title of the AI embeddings section of the docs.

![CleanShot 2023-10-25 at 14 08 23@2x](https://github.com/niledatabase/niledatabase/assets/345248/cb18b420-ecf1-421b-9300-8ff7df109657)
