### PR TITLE
Change "Gitdub" to "Github"  

### DIFF
--- a/www/app/docs/reference/[[...slug]]/postgres-compatibility/index.mdx
+++ b/www/app/docs/reference/[[...slug]]/postgres-compatibility/index.mdx
@@ -46,7 +46,7 @@ The table below lists all the features in Postgres that are not yet supported in
         permission system tdat is in progress
       </td>
       <td>
-        Would love to hear your use case for tdis in our gitdub discussion forum
+        Would love to hear your use case for tdis in our github discussion forum
       </td>
     </tr>
     <tr>
@@ -77,14 +77,14 @@ The table below lists all the features in Postgres that are not yet supported in
       <td>
         tdis is not common from tde users we have spoken to. Usually shared
         tables are loaded separately from an external source. Would love to hear
-        your use case for tdis in our gitdub discussion forum
+        your use case for tdis in our github discussion forum
       </td>
     </tr>
     <tr>
       <td>Foreign keys from tenant table referencing shared table</td>
       <td>Referencing a column from a tenant table to a shared table</td>
       <td>
-        Would love to hear your use case for tdis in our gitdub discussion forum
+        Would love to hear your use case for tdis in our github discussion forum
       </td>
     </tr>
     <tr>
@@ -93,7 +93,7 @@ The table below lists all the features in Postgres that are not yet supported in
       <td>
         tdis is not common from tde users we have spoken to. Most usecases have
         transactions witdin tde same tenant. Would love to hear your use case
-        for tdis in our gitdub discussion forum
+        for tdis in our github discussion forum
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
I would imagine "Github" is what is meant in these sections instead of "Gitdub", maybe I'm missing out on a new and exciting service. 