### PR TITLE
fix serialization scenario in transactions blog

### DIFF
--- a/www/app/blog/2023-12-18-transaction-isolation-postgres.mdx
+++ b/www/app/blog/2023-12-18-transaction-isolation-postgres.mdx
@@ -600,20 +600,20 @@ What are serialization errors? They look something like this: `ERROR: could not 
     <tr>
       <td>
         {/* prettier-ignore */}
-        <pre>BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE; 
+        <pre>BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
         select * from accounts;</pre>
       </td>
       <td>
         {/* prettier-ignore */}
-        <pre>BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE; 
-        select * from accounts;</pre>      
-        </td>
+        <pre>BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+        select * from accounts;</pre>
+      </td>
     </tr>
     <tr>
       <td></td>
       <td>
-      {/* prettier-ignore */}
-        <pre>UPDATE accounts set balance = 500 
+        {/* prettier-ignore */}
+        <pre>UPDATE accounts set balance = 500
         where acctnum = 789;
         COMMIT;</pre>
       </td>
@@ -621,7 +621,7 @@ What are serialization errors? They look something like this: `ERROR: could not 
     <tr>
       <td>
         {/* prettier-ignore */}
-        <pre>UPDATE accounts set balance = balance+200 
+        <pre>UPDATE accounts set balance = balance+200
         where acctnum = 789;</pre>
       </td>
       <td></td>

--- a/www/app/blog/2023-12-18-transaction-isolation-postgres.mdx
+++ b/www/app/blog/2023-12-18-transaction-isolation-postgres.mdx
@@ -599,30 +599,33 @@ What are serialization errors? They look something like this: `ERROR: could not 
   <tbody>
     <tr>
       <td>
-        {/* prettier-ignore */}
-        <pre>BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
-        select * from accounts;</pre>
+        ```sql
+        BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+        select * from accounts;
+        ```
       </td>
       <td>
-        {/* prettier-ignore */}
-        <pre>BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
-        select * from accounts;</pre>
+        ```sql
+        BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+        select * from accounts;
+        ```
       </td>
     </tr>
     <tr>
       <td></td>
       <td>
-        {/* prettier-ignore */}
-        <pre>UPDATE accounts set balance = 500
-        where acctnum = 789;
-        COMMIT;</pre>
+        ```sql
+        UPDATE accounts set balance = 500 where acctnum = 789;
+        COMMIT;
+        ```
       </td>
     </tr>
     <tr>
       <td>
-        {/* prettier-ignore */}
-        <pre>UPDATE accounts set balance = balance+200
-        where acctnum = 789;</pre>
+        ```sql
+        UPDATE accounts set balance = balance+200
+        where acctnum = 789;
+        ```   
       </td>
       <td></td>
     </tr>

--- a/www/app/blog/2023-12-18-transaction-isolation-postgres.mdx
+++ b/www/app/blog/2023-12-18-transaction-isolation-postgres.mdx
@@ -598,34 +598,37 @@ What are serialization errors? They look something like this: `ERROR: could not 
   </thead>
   <tbody>
     <tr>
+      {/* prettier-ignore */}
       <td>
         ```sql
         BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
         select * from accounts;
         ```
       </td>
+      {/* prettier-ignore */}
       <td>
         ```sql
         BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
-        select * from accounts;
+        SELECT * FROM accounts;
         ```
       </td>
     </tr>
     <tr>
       <td></td>
+      {/* prettier-ignore */}
       <td>
         ```sql
-        UPDATE accounts set balance = 500 where acctnum = 789;
+        UPDATE accounts SET balance = 500 WHERE acctnum = 789;
         COMMIT;
         ```
       </td>
     </tr>
     <tr>
+      {/* prettier-ignore */}
       <td>
         ```sql
-        UPDATE accounts set balance = balance+200
-        where acctnum = 789;
-        ```   
+        UPDATE accounts SET balance = balance+200 WHERE acctnum = 789;
+        ```
       </td>
       <td></td>
     </tr>

--- a/www/app/blog/2023-12-18-transaction-isolation-postgres.mdx
+++ b/www/app/blog/2023-12-18-transaction-isolation-postgres.mdx
@@ -599,40 +599,37 @@ What are serialization errors? They look something like this: `ERROR: could not 
   <tbody>
     <tr>
       <td>
-        <pre>BEGIN;</pre>
+        {/* prettier-ignore */}
+        <pre>BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE; 
+        select * from accounts;</pre>
       </td>
       <td>
-        <pre>BEGIN;</pre>
+        {/* prettier-ignore */}
+        <pre>BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE; 
+        select * from accounts;</pre>      
+        </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>
+      {/* prettier-ignore */}
+        <pre>UPDATE accounts set balance = 500 
+        where acctnum = 789;
+        COMMIT;</pre>
       </td>
     </tr>
     <tr>
       <td>
         {/* prettier-ignore */}
-        <pre>UPDATE accounts set balance = 500 
+        <pre>UPDATE accounts set balance = balance+200 
         where acctnum = 789;</pre>
       </td>
       <td></td>
     </tr>
-    <tr>
-      <td>
-        <pre>COMMIT;</pre>
-      </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td></td>
-      <td>
-        {/* prettier-ignore */}
-        <pre>
-          UPDATE accounts set balance = balance+200 
-          where acctnum = 789;
-        </pre>
-      </td>
-    </tr>
   </tbody>
 </table>
 
-The transaction in session B is attempting to modify a value that session A modified and committed after session B started. Which means that session B is trying to update a value without being able to see its latest version. Which can lead to a state that would never have happened if the transactions ran serially (this anomaly is called a lost write). Therefore Session B will get an error, the transaction will roll back, and Session B can try again.
+The transaction in session A is attempting to modify a value that session B modified and committed after session A started and took a snapshot. Which means that session A is trying to update a value without being able to see its latest version. Which can lead to a state that would never have happened if the transactions ran serially (this anomaly is called a lost write). Therefore session A will get an error, the transaction will roll back, and session A can try again.
 
 Worth noting that in this simple scenario, "read committed" will actually work correctly. Session A will lock the row and session B will wait until the lock is released, then see the new value and update it. And as we've seen, "read committed" will require explicit locks for correctness in more complex situations.
 


### PR DESCRIPTION
- updated the serialization isolation example to actually reproduce the serialization error
- formatting
