### PR TITLE
docs:typo404

### DIFF
--- a/examples/integrations/stripe_subscription/README.md
+++ b/examples/integrations/stripe_subscription/README.md
@@ -16,7 +16,7 @@ Sign up for an invite to [Nile](https://thenile.dev) if you don't have one alrea
 
 ### 2. Extend tenants table
 
-After you created a database, you will land in Nile's query editor. Stripe integration requires storing customer and subscription IDs. 
+After you created a database, you will land in Nile's query editor. Stripe integration requires storing customer and subscription IDs.
 For that, we'll extend the built-in `tenants` table:
 
 ```sql
@@ -29,14 +29,14 @@ If all went well, you'll see the new columns in the panel on the left side of th
 
 ### 3. Getting credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
 
 ### 4. Setting the environment
 
 If you haven't cloned this project yet, now will be an excellent time to do so. Since it uses NextJS, we can use `create-next-app` for this:
 
 ```bash
-npx create-next-app -e https://github.com/niledatabase/niledatabase/tree/main/examples/intergrations/stripe_subscription stripe_subscription 
+npx create-next-app -e https://github.com/niledatabase/niledatabase/tree/main/examples/intergrations/stripe_subscription stripe_subscription
 cd nile-todo
 ```
 
@@ -64,7 +64,7 @@ STRIPE_SECRET_KEY = "sk_test_51Nn2AgJ5..."
 
 # The URL of the Nile API
 # Use this to instantiate Nile Server context for server-side use of the "api" SDK
-NEXT_PUBLIC_NILE_API=https://api.thenile.dev 
+NEXT_PUBLIC_NILE_API=https://api.thenile.dev
 
 # Uncomment if you want to try Google Auth
 # AUTH_TYPE=google

--- a/examples/integrations/stripe_subscription/README.md
+++ b/examples/integrations/stripe_subscription/README.md
@@ -16,7 +16,7 @@ Sign up for an invite to [Nile](https://thenile.dev) if you don't have one alrea
 
 ### 2. Extend tenants table
 
-After you created a database, you will land in Nile's query editor. Stripe integration requires storing customer and subscription IDs.
+After you created a database, you will land in Nile's query editor. Stripe integration requires storing customer and subscription IDs. 
 For that, we'll extend the built-in `tenants` table:
 
 ```sql
@@ -29,14 +29,14 @@ If all went well, you'll see the new columns in the panel on the left side of th
 
 ### 3. Getting credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
 
 ### 4. Setting the environment
 
 If you haven't cloned this project yet, now will be an excellent time to do so. Since it uses NextJS, we can use `create-next-app` for this:
 
 ```bash
-npx create-next-app -e https://github.com/niledatabase/niledatabase/tree/main/examples/intergrations/stripe_subscription stripe_subscription
+npx create-next-app -e https://github.com/niledatabase/niledatabase/tree/main/examples/intergrations/stripe_subscription stripe_subscription 
 cd nile-todo
 ```
 
@@ -64,7 +64,7 @@ STRIPE_SECRET_KEY = "sk_test_51Nn2AgJ5..."
 
 # The URL of the Nile API
 # Use this to instantiate Nile Server context for server-side use of the "api" SDK
-NEXT_PUBLIC_NILE_API=https://api.thenile.dev
+NEXT_PUBLIC_NILE_API=https://api.thenile.dev 
 
 # Uncomment if you want to try Google Auth
 # AUTH_TYPE=google

--- a/examples/quickstart/nextjs/README.md
+++ b/examples/quickstart/nextjs/README.md
@@ -24,7 +24,7 @@ If all went well, you'll see the new table in the panel on the left hand side of
 
 ### 3. Getting credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
 
 ### 4. Setting the environment
 
@@ -58,7 +58,7 @@ NILE_PASSWORD = "0d11b8e5-fbbc-4639-be44-8ab72947ec5b"
 
 # The URL of the Nile API
 # Use this to instantiate Nile Server context for server-side use of the "api" SDK
-NEXT_PUBLIC_NILE_API=https://api.thenile.dev
+NEXT_PUBLIC_NILE_API=https://api.thenile.dev 
 
 # Uncomment if you want to try Google Auth
 # AUTH_TYPE=google

--- a/examples/quickstart/nextjs/README.md
+++ b/examples/quickstart/nextjs/README.md
@@ -24,7 +24,7 @@ If all went well, you'll see the new table in the panel on the left hand side of
 
 ### 3. Getting credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
 
 ### 4. Setting the environment
 
@@ -58,7 +58,7 @@ NILE_PASSWORD = "0d11b8e5-fbbc-4639-be44-8ab72947ec5b"
 
 # The URL of the Nile API
 # Use this to instantiate Nile Server context for server-side use of the "api" SDK
-NEXT_PUBLIC_NILE_API=https://api.thenile.dev 
+NEXT_PUBLIC_NILE_API=https://api.thenile.dev
 
 # Uncomment if you want to try Google Auth
 # AUTH_TYPE=google

--- a/examples/quickstart/node_react/README.md
+++ b/examples/quickstart/node_react/README.md
@@ -24,7 +24,7 @@ If all went well, you'll see the new table in the panel on the left hand side of
 
 ### 3. Getting credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
 
 ### 4. Setting the environment
 

--- a/examples/quickstart/node_react/README.md
+++ b/examples/quickstart/node_react/README.md
@@ -24,7 +24,7 @@ If all went well, you'll see the new table in the panel on the left hand side of
 
 ### 3. Getting credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
 
 ### 4. Setting the environment
 

--- a/examples/user_management/NextAuth/README.md
+++ b/examples/user_management/NextAuth/README.md
@@ -66,7 +66,7 @@ Those should also show up on the left panel.
 
 ### 4. Getting credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
 
 ### 5. Setting the environment
 

--- a/examples/user_management/NextAuth/README.md
+++ b/examples/user_management/NextAuth/README.md
@@ -66,7 +66,7 @@ Those should also show up on the left panel.
 
 ### 4. Getting credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
 
 ### 5. Setting the environment
 

--- a/www/app/blog/2023-01-17-storage-compute-separation.mdx
+++ b/www/app/blog/2023-01-17-storage-compute-separation.mdx
@@ -19,7 +19,7 @@ Let's start at the beginning - A single machine with local SSDs was pretty commo
   src="https://www.youtube.com/embed/oi4nDjrZTKY"
   title="YouTube video player"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  allowFullscreen
+  allowFullScreen
 ></iframe>
 
 ## Compute-Storage Separation

--- a/www/app/docs/getting-started/[[...slug]]/languages/index.mdx
+++ b/www/app/docs/getting-started/[[...slug]]/languages/index.mdx
@@ -5,7 +5,7 @@ export const metadata = {
   description: "Languages and frameworks",
 };
 
-Start trying out Nile using your most familar lnaguage. If you don't have the language or framework you are looking for, let us know on our [Github discussion forum](https://github.com/orgs/niledatabase/discussions) or [Discord community](https://discord.gg/8UuBB84tTy).
+Start trying out Nile using your most familar language. If you don't have the language or framework you are looking for, let us know on our [Github discussion forum](https://github.com/orgs/niledatabase/discussions) or [Discord community](https://discord.gg/8UuBB84tTy).
 
 <Cards>
   <Card file="./languages/sql.mdx" root="getting-started" />

--- a/www/app/docs/getting-started/[[...slug]]/languages/java.mdx
+++ b/www/app/docs/getting-started/[[...slug]]/languages/java.mdx
@@ -45,7 +45,7 @@ See the `tenant_id` column? By specifying this column, You are making the table 
 
 ## 3. Get credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
 
 ## 4. Set the environment
 

--- a/www/app/docs/getting-started/[[...slug]]/languages/java.mdx
+++ b/www/app/docs/getting-started/[[...slug]]/languages/java.mdx
@@ -45,7 +45,7 @@ See the `tenant_id` column? By specifying this column, You are making the table 
 
 ## 3. Get credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
 
 ## 4. Set the environment
 

--- a/www/app/docs/getting-started/[[...slug]]/languages/nextjs.mdx
+++ b/www/app/docs/getting-started/[[...slug]]/languages/nextjs.mdx
@@ -45,7 +45,7 @@ See the `tenant_id` column? By specifying this column, You are making the table 
 
 ## 3. Get credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
 
 ## 4. Set the environment
 

--- a/www/app/docs/getting-started/[[...slug]]/languages/nextjs.mdx
+++ b/www/app/docs/getting-started/[[...slug]]/languages/nextjs.mdx
@@ -45,7 +45,7 @@ See the `tenant_id` column? By specifying this column, You are making the table 
 
 ## 3. Get credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
 
 ## 4. Set the environment
 

--- a/www/app/docs/getting-started/[[...slug]]/languages/node.mdx
+++ b/www/app/docs/getting-started/[[...slug]]/languages/node.mdx
@@ -45,7 +45,7 @@ See the `tenant_id` column? By specifying this column, You are making the table 
 
 ### 3. Get credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
 
 ### 4. Set the environment
 

--- a/www/app/docs/getting-started/[[...slug]]/languages/node.mdx
+++ b/www/app/docs/getting-started/[[...slug]]/languages/node.mdx
@@ -45,7 +45,7 @@ See the `tenant_id` column? By specifying this column, You are making the table 
 
 ### 3. Get credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
 
 ### 4. Set the environment
 

--- a/www/app/docs/getting-started/[[...slug]]/languages/node.mdx
+++ b/www/app/docs/getting-started/[[...slug]]/languages/node.mdx
@@ -112,7 +112,7 @@ You should see all the todos you created, and the tenants they belong to.
 
 ### 7. How does it work?
 
-The interesting part of this example is the NodeJS server. Lets take a look at [`/examples/quickstart/node_react/app.js`](https://github.com/niledatabase/niledatabase/blob/master/examples/quickstart/node_react/src/be/app.js).
+The interesting part of this example is the NodeJS server. Lets take a look at [`/examples/quickstart/node_react/app.ts`](https://github.com/niledatabase/niledatabase/blob/main/examples/quickstart/node_react/src/be/app.ts).
 
 The NodeJS server uses the [Nile JS client](https://github.com/niledatabase/nile-js) to connect to Nile.
 

--- a/www/app/docs/integrations/[[...slug]]/nextauth.mdx
+++ b/www/app/docs/integrations/[[...slug]]/nextauth.mdx
@@ -69,7 +69,7 @@ Those should also show up on the left panel.
 
 ### 4. Getting credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
 
 ### 5. Setting the environment
 

--- a/www/app/docs/integrations/[[...slug]]/nextauth.mdx
+++ b/www/app/docs/integrations/[[...slug]]/nextauth.mdx
@@ -69,7 +69,7 @@ Those should also show up on the left panel.
 
 ### 4. Getting credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
 
 ### 5. Setting the environment
 

--- a/www/app/docs/integrations/[[...slug]]/stripe.mdx
+++ b/www/app/docs/integrations/[[...slug]]/stripe.mdx
@@ -32,7 +32,7 @@ If all went well, you'll see the new columns in the panel on the left side of th
 
 ## 3. Get credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
 Also, copy and save the workspace and database names. You'll need them later.
 
 ## 4. Sign up to Stripe and Create a Product

--- a/www/app/docs/integrations/[[...slug]]/stripe.mdx
+++ b/www/app/docs/integrations/[[...slug]]/stripe.mdx
@@ -32,7 +32,7 @@ If all went well, you'll see the new columns in the panel on the left side of th
 
 ## 3. Get credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
 Also, copy and save the workspace and database names. You'll need them later.
 
 ## 4. Sign up to Stripe and Create a Product

--- a/www/app/docs/integrations/[[...slug]]/stripe.mdx
+++ b/www/app/docs/integrations/[[...slug]]/stripe.mdx
@@ -32,7 +32,7 @@ If all went well, you'll see the new columns in the panel on the left side of th
 
 ## 3. Get credentials
 
-In the left-hand menu, click on "Settings" and then select "Credentials". Generate credentails and keep them somewhere safe. These give you access to the database.
+In the left-hand menu, click on "Settings" and then select "credentials". Generate credentials and keep them somewhere safe. These give you access to the database.
 Also, copy and save the workspace and database names. You'll need them later.
 
 ## 4. Sign up to Stripe and Create a Product


### PR DESCRIPTION
1. Typos / spelling errors
2. 404 links
3. invalid dom property