### PR TITLE
fix: NextJS example had error due to misplaced await

### DIFF
--- a/examples/quickstart/drizzle/src/app.ts
+++ b/examples/quickstart/drizzle/src/app.ts
@@ -92,6 +92,7 @@ app.post("/api/tenants", async (req, res) => {
         // @ts-ignore
         return await tx
           .insert(tenant_users)
+          // @ts-ignore
           .values({ tenant_id: tenants[0].id, user_id: req.auth.user });
       });
     }

--- a/examples/quickstart/nextjs/app/api/login/route.ts
+++ b/examples/quickstart/nextjs/app/api/login/route.ts
@@ -10,7 +10,8 @@ import nile from "@/lib/NileServer";
 // The reason we need this is that this example supports both Google SSO (which has custom information) and user/password login which doesn't
 // Check the authentication quickstart for a simpler example of using the Nile SDK without custom cookies
 export async function POST(req: Request) {
-  const res = await nile.api.auth.login(req);
+  const server = await nile;
+  const res = await server.api.auth.login(req);
 
   // if signup was successful, we want to set the cookies
   if (res && res.status >= 200 && res.status < 300) {

--- a/examples/quickstart/nextjs/app/api/sign-up/route.ts
+++ b/examples/quickstart/nextjs/app/api/sign-up/route.ts
@@ -7,7 +7,8 @@ import nile from "@/lib/NileServer";
 // Note that this route must exist in this exact location for user/password signup to work
 // Nile's SignUp component posts to this route, we call Nile's signup API via the SDK
 export async function POST(req: Request) {
-  const res = await nile.api.auth.signUp(req);
+  const server = await nile;
+  const res = await server.api.auth.signUp(req);
 
   // if signup was successful, we want to set the cookies and headers, so it will log the user in too
   // Note that this is optional, check the authentication quickstart for a simpler example of using the Nile SDK for authentication

--- a/examples/quickstart/nextjs/app/tenants/[tenantid]/todos/page.tsx
+++ b/examples/quickstart/nextjs/app/tenants/[tenantid]/todos/page.tsx
@@ -26,7 +26,7 @@ export default async function Page({
 }) {
   // Here we are getting a connection to a specific tenant database for the current usr
   // if we already got such connection earlier, it will reuse the existing one
-  const tenantNile = configureNile(cookies().get("authData"), params.tenantid);
+  const tenantNile = await configureNile(cookies().get("authData"), params.tenantid);
 
   console.log(
     "showing todos for user " +

--- a/examples/quickstart/nextjs/app/tenants/[tenantid]/todos/todo-actions.tsx
+++ b/examples/quickstart/nextjs/app/tenants/[tenantid]/todos/todo-actions.tsx
@@ -11,7 +11,7 @@ export async function addTodo(
   formData: FormData
 ) {
   // Each  a Nile instance is connected to our current tenant DB with the current user permissions
-  const tenantNile = configureNile(cookies().get("authData"), tenantId);
+  const tenantNile = await configureNile(cookies().get("authData"), tenantId);
   const title = formData.get("todo");
   console.log(
     "adding Todo " +

--- a/examples/quickstart/nextjs/app/tenants/page.tsx
+++ b/examples/quickstart/nextjs/app/tenants/page.tsx
@@ -23,7 +23,7 @@ export const fetchCache = "force-no-store";
 export default async function Page() {
   // This is the tenant selector, so we use Nile with just the current user and reset tenant_id if already set
   // if Nile is already configured for this user, it will reuse the existing Nile instance
-  const nile = configureNile(cookies().get("authData"), undefined);
+  const nile = await configureNile(cookies().get("authData"), undefined);
   console.log("showing tenants page for user: " + nile.userId);
   let tenants: any = [];
 

--- a/examples/quickstart/nextjs/app/tenants/tenant-actions.tsx
+++ b/examples/quickstart/nextjs/app/tenants/tenant-actions.tsx
@@ -7,7 +7,7 @@ import { redirect } from "next/navigation";
 import { configureNile } from "@/lib/NileServer";
 
 export async function createTenant(prevState: any, formData: FormData) {
-  const nile = configureNile(cookies().get("authData"), null);
+  const nile = await configureNile(cookies().get("authData"), null);
   const tenantName = formData.get("tenantname")?.toString();
   if (!tenantName) {
     return { message: "No tenant name provided" };

--- a/examples/quickstart/nextjs/lib/AuthUtils.tsx
+++ b/examples/quickstart/nextjs/lib/AuthUtils.tsx
@@ -1,5 +1,4 @@
 import { JwtPayload } from "jwt-decode";
-import nile from "@/lib/NileServer";
 
 export default interface AuthCookieData {
   accessToken: string | undefined;

--- a/examples/quickstart/nextjs/lib/NileServer.ts
+++ b/examples/quickstart/nextjs/lib/NileServer.ts
@@ -4,18 +4,19 @@ import AuthCookieData from "@/lib/AuthUtils";
 // Initialize the Nile server object for reuse in all pages
 // Note that the Nile server configuration points to Nile APIs as the base path
 
-const nile = await Nile();
+const nile = Nile();
 
 export default nile;
 
 // This returns a reference to the Nile Server, configured with the user's auth token and tenantID (if any)
 // If Nile already have a connection to the same tenant database for the same user, we'll return an existing connection
-export function configureNile(
+export async function configureNile(
   rawAuthCookie: any,
   tenantId: string | null | undefined
 ) {
   const authData = JSON.parse(rawAuthCookie.value) as AuthCookieData;
-  return nile.getInstance({
+  const server = await nile;
+  return server.getInstance({
     tenantId: tenantId,
     userId: authData.tokenData?.sub,
     api: {


### PR DESCRIPTION
@jrea I couldn't run the example because of this error:

```
 ⨯ SyntaxError: await is only valid in async functions and the top level bodies of modules
    at (action-browser)/./lib/NileServer.ts (/Users/gwen/tutorials/niledatabase/examples/quickstart/nextjs/.next/server/app/tenants/page.js:404:1)
    at __webpack_require__ (/Users/gwen/tutorials/niledatabase/examples/quickstart/nextjs/.next/server/webpack-runtime.js:33:42)
    at eval (./app/tenants/tenant-actions.tsx:12:73)
    at (action-browser)/./app/tenants/tenant-actions.tsx (/Users/gwen/tutorials/niledatabase/examples/quickstart/nextjs/.next/server/app/tenants/page.js:382:1)
    at Function.__webpack_require__ (/Users/gwen/tutorials/niledatabase/examples/quickstart/nextjs/.next/server/webpack-runtime.js:33:42)
```

I'm not sure how this worked before, but I did my best to fix this. 

Can you please review, and let me know if there's a better way to handle the now async Nile initialization step? 