### PR TITLE
chore: update example config in nextjs quickstart

### DIFF
--- a/examples/quickstart/nextjs/README.md
+++ b/examples/quickstart/nextjs/README.md
@@ -35,33 +35,28 @@ npx create-next-app -e https://github.com/niledatabase/niledatabase/tree/main/ex
 cd nile-todo
 ```
 
-Rename `.env.local.example` to `.env.local`, and update it with your workspace and database name.
-_(Your workspace and database name are displayed in the header of the Nile dashboard.)_
-Also fill in the username and password with the credentials you picked up in the previous step.
+Rename `.env.local.example` to `.env.local`, and fill in the username and password with the 
+credentials you picked up in the previous step.
 
 It should look something like this:
 
 ```bash
+
+# Private env vars that should never show up in the browser
+# These are used by the server to connect to Nile database
+NILE_USER = "0190995c-44ab-7ce3-9aef-31ef87dcd5f0"
+NILE_PASSWORD = "73d32231-1d21-4990-a4f4-g6447507c271"
+
 # Client (public) env vars
 
 # the URL of this example + where the api routes are located
 # Use this to instantiate Nile context for client-side components
-NEXT_PUBLIC_BASE_PATH=http://localhost:3000/api
-NEXT_PUBLIC_WORKSPACE=todoapp_demo
-NEXT_PUBLIC_DATABASE=demo_db_nextjs_qs
-
-# Private env vars that should never show up in the browser
-# These are used by the server to connect to Nile database
-NILE_DB_HOST = "db.thenile.dev"
-NILE_USER = "018ad484-0d52-7274-8639-057814be60c3"
-NILE_PASSWORD = "0d11b8e5-fbbc-4639-be44-8ab72947ec5b"
-
-# The URL of the Nile API
-# Use this to instantiate Nile Server context for server-side use of the "api" SDK
-NEXT_PUBLIC_NILE_API=https://api.thenile.dev
+NEXT_PUBLIC_APP_URL=http://localhost:3000/api
 
 # Uncomment if you want to try Google Auth
+# NEXT_PUBLIC_NILEDB_API_URL=
 # AUTH_TYPE=google
+
 ```
 
 Install dependencies with `yarn install` or `npm install`.


### PR DESCRIPTION
This modifies the example configuration to reflect [changes made](https://github.com/niledatabase/niledatabase/pull/356/files#diff-c9bc9f7760f667123f3a63ab2deb3d1060c9a7f4733dcd2f1af148c1a0ea4c3a) when upgrading to SDK version 2.4.0. Only the username and password of the generated credential are required now; the SDK uses these to authenticate and obtain any other necessary information about the workspace and database.

Though commented out, this also updates the param that necessary for Google SSO from `NEXT_PUBLIC_NILE_API` to `NEXT_PUBLIC_NILEDB_API_URL`, which can be obtained on the "Database settings" screen in the console:

<img width="864" alt="image" src="https://github.com/niledatabase/niledatabase/assets/923236/342f29b1-0445-4597-bec5-fb9b2473da38">

The email/password login and Google SSO login are mutually exclusive; the demo runs in one mode or the other:
- In email/password mode, only the `NILE_USER` and `NILE_PASSWORD` are required. 
- In Google SSO mode, only the `NEXT_PUBLIC_NILEDB_API_URL` is required, and the `AUTH_TYPE` should be set to `google`.