### PR TITLE
Make AI optional in NextJS example

### DIFF
--- a/examples/quickstart/nextjs/app/tenants/[tenantid]/todos/todo-actions.tsx
+++ b/examples/quickstart/nextjs/app/tenants/[tenantid]/todos/todo-actions.tsx
@@ -34,14 +34,20 @@ export async function addTodo(
     return { message: "Please enter a title" };
   }
 
+  let timeToEmbedTask = 0;
+  let timeToFindSimilarTasks = 0;
+  let timeToAiEstimate = 0;
+  let embedding = null;
+  let estimate = "Can't generate estimate because AI is not configured"
+  
   try {
     // if AI is configured, we generate embeddings and estimate for the task
     if (process.env.AI_API_KEY) {
       // We also want to try and embed the task for future AI processing
       startTime = performance.now();
-      const embedding = await embedTask(title.toString());
+      embedding = await embedTask(title.toString());
       endTime = performance.now();
-      let timeToEmbedTask = endTime - startTime;
+      timeToEmbedTask = endTime - startTime;
       // use embeddings to get some similar tasks, for reference
       startTime = performance.now();
       const similarTasks = await findSimilarTasks(
@@ -50,22 +56,16 @@ export async function addTodo(
         embedding
       );
       endTime = performance.now();
-      let timeToFindSimilarTasks = endTime - startTime;
+      timeToFindSimilarTasks = endTime - startTime;
       // for each todo, we want to try and generate an AI estimate.
       startTime = performance.now();
-      const estimate = await aiEstimate(
+      estimate = await aiEstimate(
         tenantNile,
         title.toString(),
         similarTasks
       );
       endTime = performance.now();
-      let timeToAiEstimate = endTime - startTime;
-    } else {
-      let timeToEmbedTask = 0;
-      let timeToFindSimilarTasks = 0;
-      let timeToAiEstimate = 0;
-      let embedding = null;
-      let estimate = "Can't generate estimate because AI is not configured"
+      timeToAiEstimate = endTime - startTime;
     }
 
     // need to set tenant ID because it is part of the primary key

--- a/examples/quickstart/nextjs/app/tenants/[tenantid]/todos/todo-actions.tsx
+++ b/examples/quickstart/nextjs/app/tenants/[tenantid]/todos/todo-actions.tsx
@@ -35,29 +35,38 @@ export async function addTodo(
   }
 
   try {
-    // We also want to try and embed the task for future AI processing
-    startTime = performance.now();
-    const embedding = await embedTask(title.toString());
-    endTime = performance.now();
-    let timeToEmbedTask = endTime - startTime;
-    // use embeddings to get some similar tasks, for reference
-    startTime = performance.now();
-    const similarTasks = await findSimilarTasks(
-      tenantNile,
-      title.toString(),
-      embedding
-    );
-    endTime = performance.now();
-    let timeToFindSimilarTasks = endTime - startTime;
-    // for each todo, we want to try and generate an AI estimate.
-    startTime = performance.now();
-    const estimate = await aiEstimate(
-      tenantNile,
-      title.toString(),
-      similarTasks
-    );
-    endTime = performance.now();
-    let timeToAiEstimate = endTime - startTime;
+    // if AI is configured, we generate embeddings and estimate for the task
+    if (process.env.AI_API_KEY) {
+      // We also want to try and embed the task for future AI processing
+      startTime = performance.now();
+      const embedding = await embedTask(title.toString());
+      endTime = performance.now();
+      let timeToEmbedTask = endTime - startTime;
+      // use embeddings to get some similar tasks, for reference
+      startTime = performance.now();
+      const similarTasks = await findSimilarTasks(
+        tenantNile,
+        title.toString(),
+        embedding
+      );
+      endTime = performance.now();
+      let timeToFindSimilarTasks = endTime - startTime;
+      // for each todo, we want to try and generate an AI estimate.
+      startTime = performance.now();
+      const estimate = await aiEstimate(
+        tenantNile,
+        title.toString(),
+        similarTasks
+      );
+      endTime = performance.now();
+      let timeToAiEstimate = endTime - startTime;
+    } else {
+      let timeToEmbedTask = 0;
+      let timeToFindSimilarTasks = 0;
+      let timeToAiEstimate = 0;
+      let embedding = null;
+      let estimate = "Can't generate estimate because AI is not configured"
+    }
 
     // need to set tenant ID because it is part of the primary key
     startTime = performance.now();

--- a/examples/quickstart/nextjs/app/tenants/[tenantid]/todos/todo-actions.tsx
+++ b/examples/quickstart/nextjs/app/tenants/[tenantid]/todos/todo-actions.tsx
@@ -38,7 +38,7 @@ export async function addTodo(
   let timeToFindSimilarTasks = 0;
   let timeToAiEstimate = 0;
   let embedding = null;
-  let estimate = "Can't generate estimate because AI is not configured"
+  let estimate: string | null  = "Can't generate estimate because AI is not configured"
   
   try {
     // if AI is configured, we generate embeddings and estimate for the task

--- a/examples/quickstart/nextjs/lib/AiUtils.tsx
+++ b/examples/quickstart/nextjs/lib/AiUtils.tsx
@@ -1,8 +1,8 @@
 import { Server } from "@niledatabase/server";
 import { OpenAI } from "openai";
 
-export function embeddingToSQL(embedding: number[]) {
-  return JSON.stringify(embedding);
+export function embeddingToSQL(embedding: number[] | null) {
+  return embedding ? JSON.stringify(embedding) : null;
 }
 
 export async function embedTask(title: string) {


### PR DESCRIPTION
If AI API Key is configured, the example will use AI, but if someone doesn't have it configured (perhaps because they are trying to deploy to Vercel in one click), everything will still work. The estimate column will say that AI isn't configured. 