### PR TITLE
fix(prisma): Update build-in schema definition

### DIFF
--- a/examples/quickstart/prisma/prisma/schema.prisma
+++ b/examples/quickstart/prisma/prisma/schema.prisma
@@ -60,6 +60,7 @@ model users {
   given_name  String?
   email       String?
   picture     String?
+  email_verified DateTime? @db.Timestamp(6)
 
   @@schema("users")
 }


### PR DESCRIPTION
The schema 'users.users' now contains the attribute 'email_verified'. Added the attribute to the schema definition to Prevent prisma from dropping this attribute.